### PR TITLE
[issue-21] Prevent focus outside modal

### DIFF
--- a/app/javascript/controllers/ui/dialog_controller.js
+++ b/app/javascript/controllers/ui/dialog_controller.js
@@ -31,6 +31,21 @@ export default class UIDialog extends Controller {
     e.preventDefault();
   }
 
+  handleFocusEvent(e) {
+    let target = this.dialogTarget;
+    let shiftPressed = e.shiftKey;
+    // If TAB is pressed
+    if (e.keyCode === 9) {
+      let focusableElements = target.querySelectorAll("a[href], button");
+      let borderElem = shiftPressed
+        ? focusableElements[0]
+        : focusableElements[focusableElements.length - 1];
+      if (document.activeElement === borderElem) {
+        e.preventDefault();
+      }
+    }
+  }
+
   closeByKey(e) {
     if (e.keyCode == 27) {
       this.closeBy(e.target);

--- a/app/views/components/ui/_dialog.html.erb
+++ b/app/views/components/ui/_dialog.html.erb
@@ -5,6 +5,7 @@
 
   <div
     role="dialog"
+    aria-modal="true"
     data-state="closed"
     data-ui--dialog-target="dialog"
     class="<%= tw('hidden fixed left-[50%] top-[50%] z-50 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full sm:max-w-[425px]', options[:class]) %>"

--- a/app/views/components/ui/_dialog.html.erb
+++ b/app/views/components/ui/_dialog.html.erb
@@ -1,4 +1,4 @@
-<div data-controller="ui--dialog">
+<div data-controller="ui--dialog" data-action="keydown->ui--dialog#handleFocusEvent">
   <div data-action="click->ui--dialog#open"><%= content_for(:dialog_trigger) %></div>
 
   <%= render "components/ui/shared/backdrop", as: "modal" %>


### PR DESCRIPTION
issue: [#21](https://github.com/aviflombaum/shadcn-rails/issues/21)

Prevent focus outside modal by getting focusable elements inside the dialog and removing default behaviour if the next element to focus is out of bounds 

![focus-element](https://github.com/user-attachments/assets/707caa4f-7fa8-4800-ae26-8d2cbf82565c)

